### PR TITLE
Remove duplicated https://

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,12 +29,12 @@
     </a>
 
     <!-- Reddit -->
-    <a href="http://reddit.com/submit?url=https://https://forcedlabour.github.io/forcedlabourKR/&amp;title=Forced%20labour%20of%20Korea" target="_blank">
+    <a href="http://reddit.com/submit?url=https://forcedlabour.github.io/forcedlabourKR/&amp;title=Forced%20labour%20of%20Korea" target="_blank">
       <img src="https://simplesharebuttons.com/images/somacro/reddit.png" alt="Reddit" />
     </a>
 
     <!-- Twitter -->
-    <a href="https://twitter.com/share?url=https://https://forcedlabour.github.io/forcedlabourKR/&amp;text=Forced%20labour%20of%20Korea&amp;hashtags=forced_labour_of_Korea" target="_blank">
+    <a href="https://twitter.com/share?url=https://forcedlabour.github.io/forcedlabourKR/&amp;text=Forced%20labour%20of%20Korea&amp;hashtags=forced_labour_of_Korea" target="_blank">
       <img src="https://simplesharebuttons.com/images/somacro/twitter.png" alt="Twitter" />
     </a>
 


### PR DESCRIPTION
Some of SNS sharing features has parameters that contain duplicated https://.

It seems to be removed.